### PR TITLE
[Codex] router-config - Centralize routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,10 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom"
-import { PublicLayout } from "@/app/layouts/PublicLayout"
-import { DashboardLayout } from "@/app/layouts/DashboardLayout"
-
-import Home from "@/pages/Home"
-import Login from "@/pages/Login"
-import DashboardHome from "@/pages/DashboardHome"
+import { BrowserRouter } from "react-router-dom"
+import { AppRouter } from "@/app/router"
 
 function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        {/* Zona publică */}
-        <Route element={<PublicLayout />}>
-          <Route path="/" element={<Home />} />
-          <Route path="/login" element={<Login />} />
-        </Route>
-
-        {/* Zona dashboard (autentificare + superadmin) */}
-        <Route path="/dashboard" element={<DashboardLayout />}>
-          <Route index element={<DashboardHome />} />
-        </Route>
-      </Routes>
+      <AppRouter />
     </BrowserRouter>
   )
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,33 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useRoutes, type RouteObject } from "react-router-dom";
+import { PublicLayout } from "@/app/layouts/PublicLayout";
+import { DashboardLayout } from "@/app/layouts/DashboardLayout";
+import Home from "@/pages/Home";
+import Login from "@/pages/Login";
+import DashboardHome from "@/pages/DashboardHome";
+
+// Rutele de bază vizibile imediat
+export const routes: RouteObject[] = [
+  {
+    element: <PublicLayout />,
+    children: [
+      { path: "/", element: <Home /> },
+      { path: "/login", element: <Login /> },
+    ],
+  },
+  {
+    path: "/dashboard",
+    element: <DashboardLayout />,
+    children: [{ index: true, element: <DashboardHome /> }],
+  },
+];
+
+// Permite adăugarea de rute noi la runtime
+export const addRoutes = (newRoutes: RouteObject[]): void => {
+  routes.push(...newRoutes);
+};
+
+// Componență care generează routerul aplicației
+export const AppRouter = (): JSX.Element | null => {
+  return useRoutes(routes);
+};


### PR DESCRIPTION
## Summary
- create `router.tsx` with base routes and helper to add more
- use new `AppRouter` inside `App.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688474f53924832d93ae229d46d735aa