### PR TITLE
[Codex] form-validation - Use yup with react-hook-form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bee_web_service",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.0",
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/react-query": "^5.83.0",
         "axios": "^1.6.7",
@@ -17,8 +18,10 @@
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.61.1",
         "react-router-dom": "^6.22.3",
-        "tailwindcss": "^4.1.11"
+        "tailwindcss": "^4.1.11",
+        "yup": "^1.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1113,6 +1116,18 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.0.tgz",
+      "integrity": "sha512-3YI+VqxJQH6ryRWG+j3k+M19Wf37LeSKJDg6Vdjq6makLOqZGYn77iTaYLMLpVi/uHc1N6OTCmcxJwhOQV979g==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1610,6 +1625,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.11",
@@ -4923,6 +4944,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4978,6 +5005,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
+      "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {
@@ -5409,6 +5452,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -5533,6 +5582,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -5588,6 +5643,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -6044,6 +6111,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+      "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.0",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.83.0",
     "axios": "^1.6.7",
@@ -22,8 +23,10 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.61.1",
     "react-router-dom": "^6.22.3",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "yup": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/shared/components/forms/RegisterForm.test.tsx
+++ b/src/shared/components/forms/RegisterForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import RegisterForm from "./RegisterForm";
 import { vi, describe, it, expect } from "vitest";
 
@@ -8,7 +8,7 @@ vi.mock("@/hooks/useRegister", () => ({
 }));
 
 describe("RegisterForm", () => {
-  it("trimite datele completate", () => {
+  it("trimite datele completate", async () => {
     render(<RegisterForm role="client" />);
 
     fireEvent.change(screen.getByLabelText(/Email/), {
@@ -21,17 +21,19 @@ describe("RegisterForm", () => {
       target: { value: "0712345678" }
     });
     fireEvent.change(screen.getByLabelText(/Parolă/), {
-      target: { value: "parola" }
+      target: { value: "parola123" }
     });
 
     fireEvent.click(screen.getByRole("button", { name: /Creează cont/i }));
 
-    expect(mutate).toHaveBeenCalledWith({
-      email: "test@bee.ro",
-      full_name: "Ion Pop",
-      phone_number: "0712345678",
-      password: "parola",
-      role: "client"
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith({
+        email: "test@bee.ro",
+        full_name: "Ion Pop",
+        phone_number: "0712345678",
+        password: "parola123",
+        role: "client"
+      });
     });
   });
 });

--- a/src/shared/components/forms/RegisterForm.tsx
+++ b/src/shared/components/forms/RegisterForm.tsx
@@ -1,37 +1,37 @@
-import { useState } from "react";
 import { Button, Label, TextInput } from "flowbite-react";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { useRegister } from "@/hooks/useRegister";
+import {
+  registerSchema,
+  type RegisterFormValues,
+} from "@/shared/validation/registerSchema";
 
 interface RegisterFormProps {
   role: string;
 }
 
 export default function RegisterForm({ role }: RegisterFormProps) {
-  const [formData, setFormData] = useState({
-    email: "",
-    full_name: "",
-    phone_number: "",
-    password: "",
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RegisterFormValues>({
+    resolver: yupResolver(registerSchema),
   });
+
   const { mutate, isPending, error } = useRegister();
-  const validationErrors = (error && error.errors) || {};
+  const serverErrors = (error && error.errors) || {};
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
-    e.preventDefault();
-    mutate({ ...formData, role });
+  const onSubmit = (data: RegisterFormValues): void => {
+    mutate({ ...data, role });
   };
 
   return (
     <form
-      onSubmit={handleSubmit}
+      onSubmit={handleSubmit(onSubmit)}
       className="mx-auto flex max-w-md flex-col gap-4"
     >
-      <input type="hidden" name="role" value={role} />
       <div>
         <Label htmlFor="email">Email</Label>
         <TextInput
@@ -39,12 +39,13 @@ export default function RegisterForm({ role }: RegisterFormProps) {
           name="email"
           type="email"
           placeholder="name@beeconect.com"
-          required
-          value={formData.email}
-          onChange={handleChange}
+          {...register("email")}
         />
-        {validationErrors.email && (
-          <p className="text-sm text-red-500">{validationErrors.email[0]}</p>
+        {errors.email && (
+          <p className="text-sm text-red-500">{errors.email.message}</p>
+        )}
+        {serverErrors.email && (
+          <p className="text-sm text-red-500">{serverErrors.email[0]}</p>
         )}
       </div>
       <div>
@@ -54,12 +55,13 @@ export default function RegisterForm({ role }: RegisterFormProps) {
           name="full_name"
           type="text"
           placeholder="Ion Popescu"
-          required
-          value={formData.full_name}
-          onChange={handleChange}
+          {...register("full_name")}
         />
-        {validationErrors.full_name && (
-          <p className="text-sm text-red-500">{validationErrors.full_name[0]}</p>
+        {errors.full_name && (
+          <p className="text-sm text-red-500">{errors.full_name.message}</p>
+        )}
+        {serverErrors.full_name && (
+          <p className="text-sm text-red-500">{serverErrors.full_name[0]}</p>
         )}
       </div>
       <div>
@@ -69,13 +71,16 @@ export default function RegisterForm({ role }: RegisterFormProps) {
           name="phone_number"
           type="tel"
           placeholder="07********"
-          required
-          value={formData.phone_number}
-          onChange={handleChange}
+          {...register("phone_number")}
         />
-        {validationErrors.phone_number && (
+        {errors.phone_number && (
           <p className="text-sm text-red-500">
-            {validationErrors.phone_number[0]}
+            {errors.phone_number.message}
+          </p>
+        )}
+        {serverErrors.phone_number && (
+          <p className="text-sm text-red-500">
+            {serverErrors.phone_number[0]}
           </p>
         )}
       </div>
@@ -85,12 +90,13 @@ export default function RegisterForm({ role }: RegisterFormProps) {
           id="password"
           name="password"
           type="password"
-          required
-          value={formData.password}
-          onChange={handleChange}
+          {...register("password")}
         />
-        {validationErrors.password && (
-          <p className="text-sm text-red-500">{validationErrors.password[0]}</p>
+        {errors.password && (
+          <p className="text-sm text-red-500">{errors.password.message}</p>
+        )}
+        {serverErrors.password && (
+          <p className="text-sm text-red-500">{serverErrors.password[0]}</p>
         )}
       </div>
       {error && !error.errors && (

--- a/src/shared/validation/registerSchema.ts
+++ b/src/shared/validation/registerSchema.ts
@@ -1,0 +1,20 @@
+import * as yup from "yup";
+
+export const registerSchema = yup.object({
+  email: yup
+    .string()
+    .email("Email invalid")
+    .required("Emailul este obligatoriu"),
+  full_name: yup.string().required("Numele complet este obligatoriu"),
+  phone_number: yup
+    .string()
+    .matches(/^\d{10}$/, "Număr de telefon invalid")
+    .optional()
+    .nullable(),
+  password: yup
+    .string()
+    .min(8, "Parola trebuie să aibă minim 8 caractere")
+    .required("Parola este obligatorie"),
+});
+
+export type RegisterFormValues = yup.InferType<typeof registerSchema>;


### PR DESCRIPTION
## Summary
- add `yup`, `react-hook-form` and resolver deps
- create `registerSchema` for shared form validation
- update `RegisterForm` to use `react-hook-form`
- adjust tests for new validation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884859621e4832db96f7cddcf90e74c