### PR TITLE
[Codex] register-mutation - use mutationFn for registration

### DIFF
--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -12,19 +12,21 @@ interface RegisterError {
 }
 
 export const useRegister = () => {
-  return useMutation<void, RegisterError, RegisterData>(async (data) => {
-    try {
-      await registerUser(data);
-    } catch (err) {
-      const error = err as AxiosError<{ errors?: ValidationErrors }>;
-      if (axios.isAxiosError(error) && error.response?.status === 422) {
-        // Erorile de validare venite de la server
-        throw {
-          message: "Date invalide",
-          errors: (error.response.data as { errors?: ValidationErrors }).errors,
-        };
+  return useMutation<void, RegisterError, RegisterData>({
+    mutationFn: async (data: RegisterData) => {
+      try {
+        await registerUser(data);
+      } catch (err) {
+        const error = err as AxiosError<{ errors?: ValidationErrors }>;
+        if (axios.isAxiosError(error) && error.response?.status === 422) {
+          // Erorile de validare venite de la server
+          throw {
+            message: "Date invalide",
+            errors: (error.response.data as { errors?: ValidationErrors }).errors,
+          };
+        }
+        throw { message: "Eroare la înregistrare" };
       }
-      throw { message: "Eroare la înregistrare" };
-    }
+    },
   });
 };


### PR DESCRIPTION
## Summary
- use `mutationFn` parameter in `useRegister`

## Testing
- `npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68848a239ad8832d83af4e599fcc66f3