### PR TITLE
[Codex] register-form-types - Align type definitions

### DIFF
--- a/src/shared/components/forms/RegisterForm.tsx
+++ b/src/shared/components/forms/RegisterForm.tsx
@@ -1,5 +1,5 @@
 import { Button, Label, TextInput } from "flowbite-react";
-import { useForm } from "react-hook-form";
+import { useForm, type SubmitHandler, type Resolver } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useRegister } from "@/hooks/useRegister";
 import {
@@ -17,13 +17,13 @@ export default function RegisterForm({ role }: RegisterFormProps) {
     handleSubmit,
     formState: { errors },
   } = useForm<RegisterFormValues>({
-    resolver: yupResolver(registerSchema),
+    resolver: yupResolver(registerSchema) as Resolver<RegisterFormValues>,
   });
 
   const { mutate, isPending, error } = useRegister();
   const serverErrors = (error && error.errors) || {};
 
-  const onSubmit = (data: RegisterFormValues): void => {
+  const onSubmit: SubmitHandler<RegisterFormValues> = (data) => {
     mutate({ ...data, role });
   };
 

--- a/src/shared/validation/registerSchema.ts
+++ b/src/shared/validation/registerSchema.ts
@@ -17,4 +17,8 @@ export const registerSchema = yup.object({
     .required("Parola este obligatorie"),
 });
 
-export type RegisterFormValues = yup.InferType<typeof registerSchema>;
+type SchemaShape = yup.InferType<typeof registerSchema>;
+
+export interface RegisterFormValues extends Omit<SchemaShape, "phone_number"> {
+  phone_number?: string | null;
+}


### PR DESCRIPTION
## Summary
- ensure phone number is optional in `RegisterFormValues`
- update `RegisterForm` types for `useForm` and `onSubmit`

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884adb6ab2c832db1853a4013c5e847