### PR TITLE
[Codex] auth - update register path

### DIFF
--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -15,6 +15,6 @@ describe("registerUser", () => {
     };
     await registerUser(data);
 
-    expect(postSpy).toHaveBeenCalledWith("/register", data);
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/register", data);
   });
 });

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -12,5 +12,5 @@ export const registerUser = async (
   data: RegisterData,
 ): Promise<void> => {
   // Trimite datele de înregistrare către microserviciul de autentificare
-  await apiClient.post("/register", data);
+  await apiClient.post("/v1/auth/register", data);
 };


### PR DESCRIPTION
## Summary
- point `registerUser` to `/v1/auth/register`
- update tests for new path

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884b735d558832d89800bbfcd68fa31