### PR TITLE
[Codex] auth-service - Add auth endpoints & tests

### DIFF
--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -1,5 +1,19 @@
 import { vi, describe, it, expect } from "vitest";
-import { registerUser } from "./auth";
+import {
+  registerUser,
+  loginUser,
+  logout,
+  refreshToken,
+  requestPasswordReset,
+  resetPassword,
+  verifyEmail,
+  verify2FA,
+  setup2FA,
+  socialLogin,
+  socialCallback,
+  currentUser,
+  validateToken,
+} from "./auth";
 import apiClient from "./apiClient";
 
 describe("registerUser", () => {
@@ -16,5 +30,132 @@ describe("registerUser", () => {
     await registerUser(data);
 
     expect(postSpy).toHaveBeenCalledWith("/v1/auth/register", data);
+  });
+});
+
+describe("loginUser", () => {
+  it("apelează API-ul cu datele de autentificare", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({ data: {} });
+
+    const data = { email: "test@bee.ro", password: "parola" };
+    await loginUser(data);
+
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/login", data);
+  });
+});
+
+describe("logout", () => {
+  it("apelează API-ul pentru logout", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+
+    await logout("token");
+
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/logout", { refresh: "token" });
+  });
+});
+
+describe("refreshToken", () => {
+  it("apelează API-ul pentru reîmprospătare", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({ data: {} });
+
+    const data = { refresh: "token" };
+    await refreshToken(data);
+
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/refresh", data);
+  });
+});
+
+describe("requestPasswordReset", () => {
+  it("apelează API-ul pentru solicitarea resetării", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+
+    const data = { email: "test@bee.ro" };
+    await requestPasswordReset(data);
+
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/password/reset", data);
+  });
+});
+
+describe("resetPassword", () => {
+  it("apelează API-ul pentru confirmarea resetării", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+
+    const data = { token: "abc", password: "nouaParola" };
+    await resetPassword(data);
+
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/password/reset/confirm", data);
+  });
+});
+
+describe("verifyEmail", () => {
+  it("apelează API-ul pentru verificarea emailului", async () => {
+    const getSpy = vi.spyOn(apiClient, "get").mockResolvedValue({});
+
+    await verifyEmail("abc");
+
+    expect(getSpy).toHaveBeenCalledWith("/v1/auth/verify-email", { params: { token: "abc" } });
+  });
+});
+
+describe("verify2FA", () => {
+  it("apelează API-ul pentru verificarea 2FA", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+
+    const data = { code: "123456" };
+    await verify2FA(data);
+
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/2fa/verify", data);
+  });
+});
+
+describe("setup2FA", () => {
+  it("apelează API-ul pentru configurarea 2FA", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({ data: {} });
+
+    const data = { email: "test@bee.ro" };
+    await setup2FA(data);
+
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/2fa/setup", data);
+  });
+});
+
+describe("socialLogin", () => {
+  it("apelează API-ul pentru social login", async () => {
+    const getSpy = vi.spyOn(apiClient, "get").mockResolvedValue({ data: {} });
+
+    await socialLogin("google");
+
+    expect(getSpy).toHaveBeenCalledWith("/v1/auth/google");
+  });
+});
+
+describe("socialCallback", () => {
+  it("apelează API-ul pentru social callback", async () => {
+    const getSpy = vi.spyOn(apiClient, "get").mockResolvedValue({ data: {} });
+
+    const query = { code: "abc" };
+    await socialCallback("google", query);
+
+    expect(getSpy).toHaveBeenCalledWith("/v1/auth/google/callback", { params: query });
+  });
+});
+
+describe("currentUser", () => {
+  it("apelează API-ul pentru obținerea utilizatorului curent", async () => {
+    const getSpy = vi.spyOn(apiClient, "get").mockResolvedValue({ data: {} });
+
+    await currentUser();
+
+    expect(getSpy).toHaveBeenCalledWith("/v1/auth/me");
+  });
+});
+
+describe("validateToken", () => {
+  it("apelează API-ul pentru validarea tokenului", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+
+    await validateToken("abc");
+
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/validate-token", { token: "abc" });
   });
 });

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -14,3 +14,141 @@ export const registerUser = async (
   // Trimite datele de înregistrare către microserviciul de autentificare
   await apiClient.post("/v1/auth/register", data);
 };
+
+export interface UserLogin {
+  email: string;
+  password: string;
+}
+
+export interface JwtPair {
+  access: string;
+  refresh: string;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  full_name: string;
+  phone_number?: string | null;
+  role: string;
+}
+
+export interface LoginResponse {
+  tokens: JwtPair;
+  user: User;
+}
+
+export interface RefreshTokenRequest {
+  refresh: string;
+}
+
+export const loginUser = async (
+  data: UserLogin,
+): Promise<LoginResponse> => {
+  // Trimite cererea de autentificare
+  const response = await apiClient.post<LoginResponse>("/v1/auth/login", data);
+  return response.data;
+};
+
+export const logout = async (refreshToken: string): Promise<void> => {
+  // Invalidează tokenul de reîmprospătare pe server
+  await apiClient.post("/v1/auth/logout", { refresh: refreshToken });
+};
+
+export const refreshToken = async (
+  refresh: RefreshTokenRequest,
+): Promise<JwtPair> => {
+  // Obține un nou set de token-uri
+  const response = await apiClient.post<JwtPair>("/v1/auth/refresh", refresh);
+  return response.data;
+};
+
+export interface PasswordResetRequest {
+  email: string;
+}
+
+export const requestPasswordReset = async (
+  data: PasswordResetRequest,
+): Promise<void> => {
+  // Solicită resetarea parolei
+  await apiClient.post("/v1/auth/password/reset", data);
+};
+
+export interface ResetPasswordData {
+  token: string;
+  password: string;
+}
+
+export const resetPassword = async (
+  data: ResetPasswordData,
+): Promise<void> => {
+  // Trimite parola nouă împreună cu tokenul primit pe email
+  await apiClient.post("/v1/auth/password/reset/confirm", data);
+};
+
+export const verifyEmail = async (token: string): Promise<void> => {
+  // Confirmă adresa de email pe baza tokenului
+  await apiClient.get("/v1/auth/verify-email", { params: { token } });
+};
+
+export interface TwoFactorVerify {
+  code: string;
+}
+
+export const verify2FA = async (
+  data: TwoFactorVerify,
+): Promise<void> => {
+  // Verifică codul 2FA introdus de utilizator
+  await apiClient.post("/v1/auth/2fa/verify", data);
+};
+
+export interface TwoFactorSetup {
+  email: string;
+}
+
+export interface TwoFactorSetupResponse {
+  qr: string;
+  secret: string;
+}
+
+export const setup2FA = async (
+  data: TwoFactorSetup,
+): Promise<TwoFactorSetupResponse> => {
+  // Inițializează configurarea 2FA pentru utilizator
+  const response = await apiClient.post<TwoFactorSetupResponse>(
+    "/v1/auth/2fa/setup",
+    data,
+  );
+  return response.data;
+};
+
+export const socialLogin = async (
+  provider: string,
+): Promise<{ url: string }> => {
+  // Obține URL-ul de redirectare către providerul social
+  const response = await apiClient.get<{ url: string }>(`/v1/auth/${provider}`);
+  return response.data;
+};
+
+export const socialCallback = async (
+  provider: string,
+  query: Record<string, string>,
+): Promise<LoginResponse> => {
+  // Procesează răspunsul providerului social
+  const response = await apiClient.get<LoginResponse>(
+    `/v1/auth/${provider}/callback`,
+    { params: query },
+  );
+  return response.data;
+};
+
+export const currentUser = async (): Promise<User> => {
+  // Returnează utilizatorul curent autentificat
+  const response = await apiClient.get<User>("/v1/auth/me");
+  return response.data;
+};
+
+export const validateToken = async (token: string): Promise<void> => {
+  // Verifică validitatea tokenului pe server
+  await apiClient.post("/v1/auth/validate-token", { token });
+};


### PR DESCRIPTION
## Summary
- extend auth service with login/logout and more
- export request/response types
- unit test auth service methods

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884b8061238832db5d43da8c04dcef0