### PR TITLE
[Codex] hooks - Add auth hooks & tests

### DIFF
--- a/src/hooks/useCurrentUser.test.tsx
+++ b/src/hooks/useCurrentUser.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect } from "vitest";
+import apiClient from "@/services/apiClient";
+import { useCurrentUser } from "./useCurrentUser";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useCurrentUser", () => {
+  it("apeleaza API-ul pentru utilizatorul curent", async () => {
+    const getSpy = vi.spyOn(apiClient, "get").mockResolvedValue({ data: {} });
+    const { result } = renderHook(() => useCurrentUser(), { wrapper });
+
+    await waitFor(() => {
+      expect(getSpy).toHaveBeenCalledWith("/v1/auth/me");
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { type AxiosError } from "axios";
+import { currentUser, type User } from "@/services/auth";
+
+interface CurrentUserError {
+  message: string;
+}
+
+export const useCurrentUser = () => {
+  return useQuery<User, AxiosError<CurrentUserError>>({
+    queryKey: ["current-user"],
+    queryFn: currentUser,
+  });
+};

--- a/src/hooks/useLogin.test.tsx
+++ b/src/hooks/useLogin.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect } from "vitest";
+import apiClient from "@/services/apiClient";
+import { useLogin } from "./useLogin";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useLogin", () => {
+  it("apeleaza API-ul de login", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({ data: {} });
+    const { result } = renderHook(() => useLogin(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ email: "test@bee.ro", password: "parola" });
+    });
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/login", {
+        email: "test@bee.ro",
+        password: "parola",
+      });
+    });
+  });
+});

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import { type AxiosError } from "axios";
+import { loginUser, type UserLogin, type LoginResponse } from "@/services/auth";
+
+interface LoginError {
+  message: string;
+}
+
+export const useLogin = () => {
+  return useMutation<LoginResponse, AxiosError<LoginError>, UserLogin>({
+    mutationFn: loginUser,
+  });
+};

--- a/src/hooks/useLogout.test.tsx
+++ b/src/hooks/useLogout.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect } from "vitest";
+import apiClient from "@/services/apiClient";
+import { useLogout } from "./useLogout";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useLogout", () => {
+  it("apeleaza API-ul de logout", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+    const { result } = renderHook(() => useLogout(), { wrapper });
+
+    act(() => {
+      result.current.mutate("token");
+    });
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/logout", { refresh: "token" });
+    });
+  });
+});

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import { type AxiosError } from "axios";
+import { logout } from "@/services/auth";
+
+interface LogoutError {
+  message: string;
+}
+
+export const useLogout = () => {
+  return useMutation<void, AxiosError<LogoutError>, string>({
+    mutationFn: logout,
+  });
+};

--- a/src/hooks/useRefreshToken.test.tsx
+++ b/src/hooks/useRefreshToken.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect } from "vitest";
+import apiClient from "@/services/apiClient";
+import { useRefreshToken } from "./useRefreshToken";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useRefreshToken", () => {
+  it("apeleaza API-ul de refresh", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({ data: {} });
+    const { result } = renderHook(() => useRefreshToken(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ refresh: "token" });
+    });
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/refresh", { refresh: "token" });
+    });
+  });
+});

--- a/src/hooks/useRefreshToken.ts
+++ b/src/hooks/useRefreshToken.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import { type AxiosError } from "axios";
+import { refreshToken, type RefreshTokenRequest, type JwtPair } from "@/services/auth";
+
+interface RefreshError {
+  message: string;
+}
+
+export const useRefreshToken = () => {
+  return useMutation<JwtPair, AxiosError<RefreshError>, RefreshTokenRequest>({
+    mutationFn: refreshToken,
+  });
+};

--- a/src/hooks/useRequestReset.test.tsx
+++ b/src/hooks/useRequestReset.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect } from "vitest";
+import apiClient from "@/services/apiClient";
+import { useRequestReset } from "./useRequestReset";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useRequestReset", () => {
+  it("apeleaza API-ul pentru resetare", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+    const { result } = renderHook(() => useRequestReset(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ email: "test@bee.ro" });
+    });
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/password/reset", { email: "test@bee.ro" });
+    });
+  });
+});

--- a/src/hooks/useRequestReset.ts
+++ b/src/hooks/useRequestReset.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import { type AxiosError } from "axios";
+import { requestPasswordReset, type PasswordResetRequest } from "@/services/auth";
+
+interface RequestResetError {
+  message: string;
+}
+
+export const useRequestReset = () => {
+  return useMutation<void, AxiosError<RequestResetError>, PasswordResetRequest>({
+    mutationFn: requestPasswordReset,
+  });
+};

--- a/src/hooks/useResetPassword.test.tsx
+++ b/src/hooks/useResetPassword.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect } from "vitest";
+import apiClient from "@/services/apiClient";
+import { useResetPassword } from "./useResetPassword";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useResetPassword", () => {
+  it("apeleaza API-ul pentru confirmare resetare", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+    const { result } = renderHook(() => useResetPassword(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ token: "abc", password: "noua" });
+    });
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/password/reset/confirm", { token: "abc", password: "noua" });
+    });
+  });
+});

--- a/src/hooks/useResetPassword.ts
+++ b/src/hooks/useResetPassword.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import { type AxiosError } from "axios";
+import { resetPassword, type ResetPasswordData } from "@/services/auth";
+
+interface ResetPasswordError {
+  message: string;
+}
+
+export const useResetPassword = () => {
+  return useMutation<void, AxiosError<ResetPasswordError>, ResetPasswordData>({
+    mutationFn: resetPassword,
+  });
+};

--- a/src/hooks/useVerify2FA.test.tsx
+++ b/src/hooks/useVerify2FA.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect } from "vitest";
+import apiClient from "@/services/apiClient";
+import { useVerify2FA } from "./useVerify2FA";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useVerify2FA", () => {
+  it("apeleaza API-ul pentru verificarea 2FA", async () => {
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue({});
+    const { result } = renderHook(() => useVerify2FA(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ code: "123" });
+    });
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/2fa/verify", { code: "123" });
+    });
+  });
+});

--- a/src/hooks/useVerify2FA.ts
+++ b/src/hooks/useVerify2FA.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import { type AxiosError } from "axios";
+import { verify2FA, type TwoFactorVerify } from "@/services/auth";
+
+interface Verify2FAError {
+  message: string;
+}
+
+export const useVerify2FA = () => {
+  return useMutation<void, AxiosError<Verify2FAError>, TwoFactorVerify>({
+    mutationFn: verify2FA,
+  });
+};

--- a/src/hooks/useVerifyEmail.test.tsx
+++ b/src/hooks/useVerifyEmail.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect } from "vitest";
+import apiClient from "@/services/apiClient";
+import { useVerifyEmail } from "./useVerifyEmail";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useVerifyEmail", () => {
+  it("apeleaza API-ul pentru verificarea email", async () => {
+    const getSpy = vi.spyOn(apiClient, "get").mockResolvedValue({});
+    const { result } = renderHook(() => useVerifyEmail(), { wrapper });
+
+    act(() => {
+      result.current.mutate("abc");
+    });
+
+    await waitFor(() => {
+      expect(getSpy).toHaveBeenCalledWith("/v1/auth/verify-email", { params: { token: "abc" } });
+    });
+  });
+});

--- a/src/hooks/useVerifyEmail.ts
+++ b/src/hooks/useVerifyEmail.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import { type AxiosError } from "axios";
+import { verifyEmail } from "@/services/auth";
+
+interface VerifyEmailError {
+  message: string;
+}
+
+export const useVerifyEmail = () => {
+  return useMutation<void, AxiosError<VerifyEmailError>, string>({
+    mutationFn: verifyEmail,
+  });
+};


### PR DESCRIPTION
## Summary
- add React Query auth hooks for login/logout/token refresh and more
- provide Vitest coverage for each hook

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884b958e27c832d8292c80c9f1dc097