### PR TITLE
[Codex] auth-context - Add context for auth tokens

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState } from "react";
+import {
+  loginUser,
+  logout as logoutService,
+  refreshToken,
+  type UserLogin,
+  type User,
+  type JwtPair,
+} from "@/services/auth";
+import { setAccessTokenGetter } from "@/services/apiClient";
+
+interface AuthContextValue {
+  user: User | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  login: (data: UserLogin) => Promise<void>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth trebuie folosit in interiorul AuthProvider");
+  }
+  return context;
+};
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [accessToken, setAccessToken] = useState<string | null>(
+    localStorage.getItem("accessToken"),
+  );
+  const [refreshTokenValue, setRefreshTokenValue] = useState<string | null>(
+    localStorage.getItem("refreshToken"),
+  );
+  const [user, setUser] = useState<User | null>(null);
+
+  const saveTokens = (tokens: JwtPair) => {
+    setAccessToken(tokens.access);
+    setRefreshTokenValue(tokens.refresh);
+    localStorage.setItem("accessToken", tokens.access);
+    localStorage.setItem("refreshToken", tokens.refresh);
+  };
+
+  const login = async (data: UserLogin) => {
+    const response = await loginUser(data);
+    saveTokens(response.tokens);
+    setUser(response.user);
+  };
+
+  const logout = async () => {
+    if (refreshTokenValue) {
+      await logoutService(refreshTokenValue);
+    }
+    setUser(null);
+    setAccessToken(null);
+    setRefreshTokenValue(null);
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+  };
+
+  const refresh = async () => {
+    if (!refreshTokenValue) return;
+    const tokens = await refreshToken({ refresh: refreshTokenValue });
+    saveTokens(tokens);
+  };
+
+  useEffect(() => {
+    setAccessTokenGetter(() => accessToken);
+  }, [accessToken]);
+
+  const value: AuthContextValue = {
+    user,
+    accessToken,
+    refreshToken: refreshTokenValue,
+    login,
+    logout,
+    refresh,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,16 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./index.css";
 import App from "./App.tsx";
+import { AuthProvider } from "@/context/AuthContext";
 
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,5 +1,13 @@
 import axios from "axios";
 
+// Functie folosită pentru a obține tokenul curent
+let accessTokenGetter: (() => string | null) | null = null;
+
+// Permite setarea funcției din exterior (AuthContext)
+export const setAccessTokenGetter = (getter: () => string | null) => {
+  accessTokenGetter = getter;
+};
+
 // Adresa de bază pentru API-ul de autentificare
 const AUTH_API_URL = import.meta.env.VITE_AUTH_API_URL || "";
 
@@ -11,10 +19,16 @@ const apiClient = axios.create({
 // Adaugă interceptor pentru request ✅
 apiClient.interceptors.request.use(
   (config) => {
-    // TODO: atașează tokenul de autentificare aici
+    // Atașează tokenul JWT dacă este disponibil
+    if (accessTokenGetter) {
+      const token = accessTokenGetter();
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+    }
     return config;
   },
-  (error) => Promise.reject(error)
+  (error) => Promise.reject(error),
 );
 
 // Adaugă interceptor pentru răspuns ✅


### PR DESCRIPTION
## Summary
- add `AuthContext` with login, logout and refresh helpers
- attach JWT token to axios requests through an interceptor
- wrap application in `AuthProvider`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884ba6fa78c832d928bc55ae005c7e8