### PR TITLE
[Codex] login-form - Implement login form component

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,12 @@
+import LoginForm from "@/shared/components/forms/LoginForm";
+
 export default function Login() {
   return (
-    <div className="text-center text-cyan-400 text-xl">
-      Autentificare în curs... 🛡️ (aici va fi formularul)
+    <div className="py-10">
+      <h2 className="mb-6 text-center text-2xl font-bold text-cyan-400">
+        Autentificare
+      </h2>
+      <LoginForm />
     </div>
-  )
+  );
 }

--- a/src/shared/components/forms/LoginForm.test.tsx
+++ b/src/shared/components/forms/LoginForm.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import LoginForm from "./LoginForm";
+import { vi, describe, it, expect } from "vitest";
+
+const mutate = vi.fn();
+vi.mock("@/hooks/useLogin", () => ({
+  useLogin: () => ({ mutate, isPending: false, error: null }),
+}));
+
+describe("LoginForm", () => {
+  it("afiseaza erori de validare", async () => {
+    render(<LoginForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Autentificare/i }));
+
+    expect(await screen.findAllByText(/obligatori/)).toHaveLength(2);
+  });
+
+  it("trimite datele completate", async () => {
+    render(<LoginForm />);
+
+    fireEvent.change(screen.getByLabelText(/Email/), {
+      target: { value: "test@bee.ro" },
+    });
+    fireEvent.change(screen.getByLabelText(/Parolă/), {
+      target: { value: "parola123" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Autentificare/i }));
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith({
+        email: "test@bee.ro",
+        password: "parola123",
+      });
+    });
+  });
+});

--- a/src/shared/components/forms/LoginForm.tsx
+++ b/src/shared/components/forms/LoginForm.tsx
@@ -1,0 +1,56 @@
+import { Button, Label, TextInput } from "flowbite-react";
+import { useForm, type SubmitHandler, type Resolver } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useLogin } from "@/hooks/useLogin";
+import {
+  loginSchema,
+  type LoginFormValues,
+} from "@/shared/validation/loginSchema";
+
+export default function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({
+    resolver: yupResolver(loginSchema) as Resolver<LoginFormValues>,
+  });
+
+  const { mutate, isPending, error } = useLogin();
+
+  // Încercăm autentificarea la submit
+  const onSubmit: SubmitHandler<LoginFormValues> = (data) => {
+    mutate(data);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="mx-auto flex max-w-md flex-col gap-4"
+    >
+      <div>
+        <Label htmlFor="email">Email</Label>
+        <TextInput
+          id="email"
+          type="email"
+          placeholder="name@beeconect.com"
+          {...register("email")}
+        />
+        {errors.email && (
+          <p className="text-sm text-red-500">{errors.email.message}</p>
+        )}
+      </div>
+      <div>
+        <Label htmlFor="password">Parolă</Label>
+        <TextInput id="password" type="password" {...register("password")} />
+        {errors.password && (
+          <p className="text-sm text-red-500">{errors.password.message}</p>
+        )}
+      </div>
+      {error && <p className="text-sm text-red-500">{error.message}</p>}
+      <Button type="submit" color="cyan" disabled={isPending}>
+        {isPending ? "Se autentifică..." : "Autentificare"}
+      </Button>
+    </form>
+  );
+}

--- a/src/shared/validation/loginSchema.ts
+++ b/src/shared/validation/loginSchema.ts
@@ -1,0 +1,8 @@
+import * as yup from "yup";
+
+export const loginSchema = yup.object({
+  email: yup.string().email("Email invalid").required("Emailul este obligatoriu"),
+  password: yup.string().required("Parola este obligatorie"),
+});
+
+export type LoginFormValues = yup.InferType<typeof loginSchema>;


### PR DESCRIPTION
## Summary
- add `loginSchema` validation with yup
- create `LoginForm` component integrated with `useLogin`
- replace placeholder in `Login.tsx` with the new form
- test login form validation and submission

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884bd626130832da9e75f209f9c4c9f