### PR TITLE
[Codex] auth-pages - Add password recovery & verification pages

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -4,6 +4,9 @@ import { PublicLayout } from "@/app/layouts/PublicLayout";
 import { DashboardLayout } from "@/app/layouts/DashboardLayout";
 import Home from "@/pages/Home";
 import Login from "@/pages/Login";
+import VerifyEmail from "@/pages/VerifyEmail";
+import RequestResetPassword from "@/pages/RequestResetPassword";
+import ResetPassword from "@/pages/ResetPassword";
 import DashboardHome from "@/pages/DashboardHome";
 import RegisterClient from "@/pages/register/RegisterClient";
 import RegisterPartner from "@/pages/register/RegisterPartner";
@@ -21,7 +24,14 @@ export const registerRoutes: RouteObject[] = [
 export const routes: RouteObject[] = [
   {
     element: <PublicLayout />,
-    children: [{ path: "/", element: <Home /> }, { path: "/login", element: <Login /> }, ...registerRoutes],
+    children: [
+      { path: "/", element: <Home /> },
+      { path: "/login", element: <Login /> },
+      { path: "/verify-email", element: <VerifyEmail /> },
+      { path: "/password/reset", element: <RequestResetPassword /> },
+      { path: "/password/reset/confirm", element: <ResetPassword /> },
+      ...registerRoutes,
+    ],
   },
   {
     path: "/dashboard",

--- a/src/pages/RequestResetPassword.tsx
+++ b/src/pages/RequestResetPassword.tsx
@@ -1,0 +1,12 @@
+import RequestResetForm from "@/shared/components/forms/RequestResetForm";
+
+export default function RequestResetPassword() {
+  return (
+    <div className="py-10">
+      <h2 className="mb-6 text-center text-2xl font-bold text-cyan-400">
+        Resetare Parolă
+      </h2>
+      <RequestResetForm />
+    </div>
+  );
+}

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,16 @@
+import { useSearchParams } from "react-router-dom";
+import ResetPasswordForm from "@/shared/components/forms/ResetPasswordForm";
+
+export default function ResetPassword() {
+  const [params] = useSearchParams();
+  const token = params.get("token") ?? "";
+
+  return (
+    <div className="py-10">
+      <h2 className="mb-6 text-center text-2xl font-bold text-cyan-400">
+        Setează Parolă Nouă
+      </h2>
+      <ResetPasswordForm token={token} />
+    </div>
+  );
+}

--- a/src/pages/VerifyEmail.tsx
+++ b/src/pages/VerifyEmail.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useVerifyEmail } from "@/hooks/useVerifyEmail";
+
+export default function VerifyEmail() {
+  const [params] = useSearchParams();
+  const token = params.get("token");
+
+  const { mutate, isPending, isSuccess, error } = useVerifyEmail();
+
+  useEffect(() => {
+    if (token) {
+      mutate(token);
+    }
+  }, [token, mutate]);
+
+  if (isSuccess) {
+    return (
+      <p className="py-10 text-center text-green-500">Email verificat cu succes!</p>
+    );
+  }
+
+  return (
+    <div className="py-10 text-center">
+      {isPending && <p>Se verifică...</p>}
+      {error && <p className="text-red-500">{error.message}</p>}
+      {!token && <p className="text-red-500">Token lipsă</p>}
+    </div>
+  );
+}

--- a/src/shared/components/forms/RequestResetForm.test.tsx
+++ b/src/shared/components/forms/RequestResetForm.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import RequestResetForm from "./RequestResetForm";
+import { vi, describe, it, expect } from "vitest";
+
+const mutate = vi.fn();
+vi.mock("@/hooks/useRequestReset", () => ({
+  useRequestReset: () => ({ mutate, isPending: false, isSuccess: false, error: null }),
+}));
+
+describe("RequestResetForm", () => {
+  it("afiseaza erori de validare", async () => {
+    render(<RequestResetForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Trimite link/i }));
+
+    expect(await screen.findAllByText(/obligatoriu/)).toHaveLength(1);
+  });
+
+  it("trimite emailul", async () => {
+    render(<RequestResetForm />);
+
+    fireEvent.change(screen.getByLabelText(/Email/), {
+      target: { value: "test@bee.ro" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Trimite link/i }));
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith({ email: "test@bee.ro" });
+    });
+  });
+});

--- a/src/shared/components/forms/RequestResetForm.tsx
+++ b/src/shared/components/forms/RequestResetForm.tsx
@@ -1,0 +1,41 @@
+import { Button, Label, TextInput } from "flowbite-react";
+import { useForm, type SubmitHandler, type Resolver } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useRequestReset } from "@/hooks/useRequestReset";
+import {
+  requestResetSchema,
+  type RequestResetValues,
+} from "@/shared/validation/requestResetSchema";
+
+export default function RequestResetForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RequestResetValues>({
+    resolver: yupResolver(requestResetSchema) as Resolver<RequestResetValues>,
+  });
+
+  const { mutate, isPending, isSuccess, error } = useRequestReset();
+
+  const onSubmit: SubmitHandler<RequestResetValues> = (data) => {
+    mutate(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="mx-auto flex max-w-md flex-col gap-4">
+      <div>
+        <Label htmlFor="email">Email</Label>
+        <TextInput id="email" type="email" placeholder="name@beeconect.com" {...register("email")}/>
+        {errors.email && <p className="text-sm text-red-500">{errors.email.message}</p>}
+      </div>
+      {error && <p className="text-sm text-red-500">{error.message}</p>}
+      {isSuccess && (
+        <p className="text-sm text-green-500">Verifică email-ul pentru link-ul de resetare.</p>
+      )}
+      <Button type="submit" color="cyan" disabled={isPending}>
+        {isPending ? "Se trimite..." : "Trimite link"}
+      </Button>
+    </form>
+  );
+}

--- a/src/shared/components/forms/ResetPasswordForm.test.tsx
+++ b/src/shared/components/forms/ResetPasswordForm.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ResetPasswordForm from "./ResetPasswordForm";
+import { vi, describe, it, expect } from "vitest";
+
+const mutate = vi.fn();
+vi.mock("@/hooks/useResetPassword", () => ({
+  useResetPassword: () => ({ mutate, isPending: false, isSuccess: false, error: null }),
+}));
+
+describe("ResetPasswordForm", () => {
+  it("afiseaza erori de validare", async () => {
+    render(<ResetPasswordForm token="abc" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Resetează/i }));
+
+    expect(await screen.findAllByText(/Parola/)).toHaveLength(1);
+  });
+
+  it("trimite parola noua", async () => {
+    render(<ResetPasswordForm token="abc" />);
+
+    fireEvent.change(screen.getByLabelText(/Parolă nouă/), {
+      target: { value: "parola123" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Resetează/i }));
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith({ token: "abc", password: "parola123" });
+    });
+  });
+});

--- a/src/shared/components/forms/ResetPasswordForm.tsx
+++ b/src/shared/components/forms/ResetPasswordForm.tsx
@@ -1,0 +1,45 @@
+import { Button, Label, TextInput } from "flowbite-react";
+import { useForm, type SubmitHandler, type Resolver } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useResetPassword } from "@/hooks/useResetPassword";
+import {
+  resetPasswordSchema,
+  type ResetPasswordValues,
+} from "@/shared/validation/resetPasswordSchema";
+
+interface ResetPasswordFormProps {
+  token: string;
+}
+
+export default function ResetPasswordForm({ token }: ResetPasswordFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetPasswordValues>({
+    resolver: yupResolver(resetPasswordSchema) as Resolver<ResetPasswordValues>,
+  });
+
+  const { mutate, isPending, isSuccess, error } = useResetPassword();
+
+  const onSubmit: SubmitHandler<ResetPasswordValues> = (data) => {
+    mutate({ ...data, token });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="mx-auto flex max-w-md flex-col gap-4">
+      <div>
+        <Label htmlFor="password">Parolă nouă</Label>
+        <TextInput id="password" type="password" {...register("password")}/>
+        {errors.password && <p className="text-sm text-red-500">{errors.password.message}</p>}
+      </div>
+      {error && <p className="text-sm text-red-500">{error.message}</p>}
+      {isSuccess && (
+        <p className="text-sm text-green-500">Parola a fost resetată cu succes.</p>
+      )}
+      <Button type="submit" color="cyan" disabled={isPending}>
+        {isPending ? "Se trimite..." : "Resetează"}
+      </Button>
+    </form>
+  );
+}

--- a/src/shared/validation/requestResetSchema.ts
+++ b/src/shared/validation/requestResetSchema.ts
@@ -1,0 +1,10 @@
+import * as yup from "yup";
+
+export const requestResetSchema = yup.object({
+  email: yup
+    .string()
+    .email("Email invalid")
+    .required("Emailul este obligatoriu"),
+});
+
+export type RequestResetValues = yup.InferType<typeof requestResetSchema>;

--- a/src/shared/validation/resetPasswordSchema.ts
+++ b/src/shared/validation/resetPasswordSchema.ts
@@ -1,0 +1,10 @@
+import * as yup from "yup";
+
+export const resetPasswordSchema = yup.object({
+  password: yup
+    .string()
+    .min(8, "Parola trebuie să aibă minim 8 caractere")
+    .required("Parola este obligatorie"),
+});
+
+export type ResetPasswordValues = yup.InferType<typeof resetPasswordSchema>;


### PR DESCRIPTION
## Summary
- add forms for requesting password reset and resetting password
- handle email verification
- add pages for reset actions and verification
- register new public routes
- test form behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884bfb91744832d8b7d9764496d7364