### PR TITLE
[Codex] auth-endpoints - Update auth service endpoints

### DIFF
--- a/src/hooks/useRequestReset.test.tsx
+++ b/src/hooks/useRequestReset.test.tsx
@@ -21,7 +21,9 @@ describe("useRequestReset", () => {
     });
 
     await waitFor(() => {
-      expect(postSpy).toHaveBeenCalledWith("/v1/auth/password/reset", { email: "test@bee.ro" });
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/request-reset", {
+        email: "test@bee.ro",
+      });
     });
   });
 });

--- a/src/hooks/useResetPassword.test.tsx
+++ b/src/hooks/useResetPassword.test.tsx
@@ -21,7 +21,10 @@ describe("useResetPassword", () => {
     });
 
     await waitFor(() => {
-      expect(postSpy).toHaveBeenCalledWith("/v1/auth/password/reset/confirm", { token: "abc", password: "noua" });
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/reset-password", {
+        token: "abc",
+        password: "noua",
+      });
     });
   });
 });

--- a/src/hooks/useVerify2FA.test.tsx
+++ b/src/hooks/useVerify2FA.test.tsx
@@ -21,7 +21,9 @@ describe("useVerify2FA", () => {
     });
 
     await waitFor(() => {
-      expect(postSpy).toHaveBeenCalledWith("/v1/auth/2fa/verify", { code: "123" });
+      expect(postSpy).toHaveBeenCalledWith("/v1/auth/verify-2fa", {
+        code: "123",
+      });
     });
   });
 });

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -72,7 +72,7 @@ describe("requestPasswordReset", () => {
     const data = { email: "test@bee.ro" };
     await requestPasswordReset(data);
 
-    expect(postSpy).toHaveBeenCalledWith("/v1/auth/password/reset", data);
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/request-reset", data);
   });
 });
 
@@ -83,7 +83,7 @@ describe("resetPassword", () => {
     const data = { token: "abc", password: "nouaParola" };
     await resetPassword(data);
 
-    expect(postSpy).toHaveBeenCalledWith("/v1/auth/password/reset/confirm", data);
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/reset-password", data);
   });
 });
 
@@ -104,7 +104,7 @@ describe("verify2FA", () => {
     const data = { code: "123456" };
     await verify2FA(data);
 
-    expect(postSpy).toHaveBeenCalledWith("/v1/auth/2fa/verify", data);
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/verify-2fa", data);
   });
 });
 
@@ -115,7 +115,7 @@ describe("setup2FA", () => {
     const data = { email: "test@bee.ro" };
     await setup2FA(data);
 
-    expect(postSpy).toHaveBeenCalledWith("/v1/auth/2fa/setup", data);
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/setup-2fa", data);
   });
 });
 
@@ -125,7 +125,9 @@ describe("socialLogin", () => {
 
     await socialLogin("google");
 
-    expect(getSpy).toHaveBeenCalledWith("/v1/auth/google");
+    expect(getSpy).toHaveBeenCalledWith("/v1/auth/social/login", {
+      params: { provider: "google" },
+    });
   });
 });
 
@@ -136,7 +138,9 @@ describe("socialCallback", () => {
     const query = { code: "abc" };
     await socialCallback("google", query);
 
-    expect(getSpy).toHaveBeenCalledWith("/v1/auth/google/callback", { params: query });
+    expect(getSpy).toHaveBeenCalledWith("/v1/auth/social/callback", {
+      params: { provider: "google", ...query },
+    });
   });
 });
 
@@ -156,6 +160,6 @@ describe("validateToken", () => {
 
     await validateToken("abc");
 
-    expect(postSpy).toHaveBeenCalledWith("/v1/auth/validate-token", { token: "abc" });
+    expect(postSpy).toHaveBeenCalledWith("/v1/auth/validate", { token: "abc" });
   });
 });

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -71,7 +71,7 @@ export const requestPasswordReset = async (
   data: PasswordResetRequest,
 ): Promise<void> => {
   // Solicită resetarea parolei
-  await apiClient.post("/v1/auth/password/reset", data);
+  await apiClient.post("/v1/auth/request-reset", data);
 };
 
 export interface ResetPasswordData {
@@ -83,7 +83,7 @@ export const resetPassword = async (
   data: ResetPasswordData,
 ): Promise<void> => {
   // Trimite parola nouă împreună cu tokenul primit pe email
-  await apiClient.post("/v1/auth/password/reset/confirm", data);
+  await apiClient.post("/v1/auth/reset-password", data);
 };
 
 export const verifyEmail = async (token: string): Promise<void> => {
@@ -99,7 +99,7 @@ export const verify2FA = async (
   data: TwoFactorVerify,
 ): Promise<void> => {
   // Verifică codul 2FA introdus de utilizator
-  await apiClient.post("/v1/auth/2fa/verify", data);
+  await apiClient.post("/v1/auth/verify-2fa", data);
 };
 
 export interface TwoFactorSetup {
@@ -116,7 +116,7 @@ export const setup2FA = async (
 ): Promise<TwoFactorSetupResponse> => {
   // Inițializează configurarea 2FA pentru utilizator
   const response = await apiClient.post<TwoFactorSetupResponse>(
-    "/v1/auth/2fa/setup",
+    "/v1/auth/setup-2fa",
     data,
   );
   return response.data;
@@ -126,7 +126,10 @@ export const socialLogin = async (
   provider: string,
 ): Promise<{ url: string }> => {
   // Obține URL-ul de redirectare către providerul social
-  const response = await apiClient.get<{ url: string }>(`/v1/auth/${provider}`);
+  const response = await apiClient.get<{ url: string }>(
+    "/v1/auth/social/login",
+    { params: { provider } },
+  );
   return response.data;
 };
 
@@ -136,8 +139,8 @@ export const socialCallback = async (
 ): Promise<LoginResponse> => {
   // Procesează răspunsul providerului social
   const response = await apiClient.get<LoginResponse>(
-    `/v1/auth/${provider}/callback`,
-    { params: query },
+    "/v1/auth/social/callback",
+    { params: { provider, ...query } },
   );
   return response.data;
 };
@@ -150,5 +153,5 @@ export const currentUser = async (): Promise<User> => {
 
 export const validateToken = async (token: string): Promise<void> => {
   // Verifică validitatea tokenului pe server
-  await apiClient.post("/v1/auth/validate-token", { token });
+  await apiClient.post("/v1/auth/validate", { token });
 };


### PR DESCRIPTION
## Summary
- switch to official auth API routes
- adjust service tests to match new endpoints
- update related hook tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884cc5b38b8832da05394523acfcfb7