### PR TITLE
[Codex] register-index - Export register pages and role constants

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -8,10 +8,12 @@ import VerifyEmail from "@/pages/VerifyEmail";
 import RequestResetPassword from "@/pages/RequestResetPassword";
 import ResetPassword from "@/pages/ResetPassword";
 import DashboardHome from "@/pages/DashboardHome";
-import RegisterClient from "@/pages/register/RegisterClient";
-import RegisterPartner from "@/pages/register/RegisterPartner";
-import RegisterCollaborator from "@/pages/register/RegisterCollaborator";
-import RegisterCourier from "@/pages/register/RegisterCourier";
+import {
+  RegisterClient,
+  RegisterPartner,
+  RegisterCollaborator,
+  RegisterCourier,
+} from "@/pages/register";
 
 export const registerRoutes: RouteObject[] = [
   { path: "/register/client", element: <RegisterClient /> },

--- a/src/pages/register/RegisterClient.tsx
+++ b/src/pages/register/RegisterClient.tsx
@@ -1,4 +1,5 @@
 import RegisterForm from "@/shared/components/forms/RegisterForm";
+import { ROLE_CLIENT } from "@/shared/constants/roles";
 
 export default function RegisterClient() {
   return (
@@ -6,7 +7,8 @@ export default function RegisterClient() {
       <h2 className="mb-6 text-center text-2xl font-bold text-cyan-400">
         Înregistrare Client
       </h2>
-      <RegisterForm role="client" />
+      {/* Trimite rolul corespunzător către formular */}
+      <RegisterForm role={ROLE_CLIENT} />
     </div>
   );
 }

--- a/src/pages/register/RegisterCollaborator.tsx
+++ b/src/pages/register/RegisterCollaborator.tsx
@@ -1,4 +1,5 @@
 import RegisterForm from "@/shared/components/forms/RegisterForm";
+import { ROLE_COLLABORATOR } from "@/shared/constants/roles";
 
 export default function RegisterCollaborator() {
   return (
@@ -6,7 +7,8 @@ export default function RegisterCollaborator() {
       <h2 className="mb-6 text-center text-2xl font-bold text-green-400">
         Înregistrare Colaborator
       </h2>
-      <RegisterForm role="collaborator" />
+      {/* Trimite rolul corespunzător către formular */}
+      <RegisterForm role={ROLE_COLLABORATOR} />
     </div>
   );
 }

--- a/src/pages/register/RegisterCourier.tsx
+++ b/src/pages/register/RegisterCourier.tsx
@@ -1,4 +1,5 @@
 import RegisterForm from "@/shared/components/forms/RegisterForm";
+import { ROLE_COURIER } from "@/shared/constants/roles";
 
 export default function RegisterCourier() {
   return (
@@ -6,7 +7,8 @@ export default function RegisterCourier() {
       <h2 className="mb-6 text-center text-2xl font-bold text-emerald-400">
         Înregistrare Curier
       </h2>
-      <RegisterForm role="courier" />
+      {/* Trimite rolul corespunzător către formular */}
+      <RegisterForm role={ROLE_COURIER} />
     </div>
   );
 }

--- a/src/pages/register/RegisterPartner.tsx
+++ b/src/pages/register/RegisterPartner.tsx
@@ -1,4 +1,5 @@
 import RegisterForm from "@/shared/components/forms/RegisterForm";
+import { ROLE_PARTNER } from "@/shared/constants/roles";
 
 export default function RegisterPartner() {
   return (
@@ -6,7 +7,8 @@ export default function RegisterPartner() {
       <h2 className="mb-6 text-center text-2xl font-bold text-yellow-400">
         Înregistrare Partener
       </h2>
-      <RegisterForm role="admin_business" />
+      {/* Trimite rolul corespunzător către formular */}
+      <RegisterForm role={ROLE_PARTNER} />
     </div>
   );
 }

--- a/src/pages/register/index.ts
+++ b/src/pages/register/index.ts
@@ -1,0 +1,4 @@
+export { default as RegisterClient } from "./RegisterClient";
+export { default as RegisterPartner } from "./RegisterPartner";
+export { default as RegisterCollaborator } from "./RegisterCollaborator";
+export { default as RegisterCourier } from "./RegisterCourier";

--- a/src/shared/constants/roles.ts
+++ b/src/shared/constants/roles.ts
@@ -1,0 +1,4 @@
+export const ROLE_CLIENT = "client";
+export const ROLE_PARTNER = "admin_business";
+export const ROLE_COLLABORATOR = "collaborator";
+export const ROLE_COURIER = "courier";


### PR DESCRIPTION
## Summary
- centralize role strings in `src/shared/constants/roles.ts`
- update register pages to use the new constants
- export all register pages via `src/pages/register/index.ts`
- import register pages from index in router

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884e783e704832d9557e2f225507411