### PR TITLE
[Codex] signup-links - Use Link in Signup dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Planificare pentru implementarea funcțiilor de înregistrare, autentificare și resetare parolă
 - Integrări viitoare cu notificări prin email și autentificare multi-factor
 - Export `registerRoutes` în router și test pentru verificarea rutelor
+- Dropdownul de înregistrare folosește acum link-uri `react-router-dom` pentru fiecare rol și închide meniul la click
 
 ## [0.1.0] - 2025-08-30
 ### Added

--- a/src/shared/components/navbar/SignupDropdown.tsx
+++ b/src/shared/components/navbar/SignupDropdown.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { UserPlus } from "lucide-react";
 import DropdownContainer from "./DropdownContainer";
-import MenuItem from "./MenuItem";
 
 const SignupDropdown = () => {
   const [open, setOpen] = useState(false);
@@ -32,38 +32,50 @@ const SignupDropdown = () => {
           <div className="text-xs font-bold text-yellow-600/80 px-3 py-1 uppercase tracking-widest flex items-center gap-2">
             <UserPlus size={16} className="text-yellow-400" /> Alege un rol:
           </div>
-          <MenuItem
+          <Link
             to="/register/client"
             onClick={() => setOpen(false)}
-            icon={<span className="text-lg">👤</span>}
-            label="Client"
-            subLabel="Cont personal"
-            className="text-yellow-700 hover:bg-yellow-100/60"
-          />
-          <MenuItem
+            className="flex items-center gap-2 hover:scale-105 transition-all px-3 py-2 rounded-xl cursor-pointer font-semibold text-base shadow-sm group text-yellow-700 hover:bg-yellow-100/60"
+          >
+            <span className="text-lg">👤</span>
+            Client
+            <span className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-xs">
+              Cont personal
+            </span>
+          </Link>
+          <Link
             to="/register/partner"
             onClick={() => setOpen(false)}
-            icon={<span className="text-lg">🤝</span>}
-            label="Partener"
-            subLabel="Business"
-            className="text-yellow-700 hover:bg-yellow-100/60"
-          />
-          <MenuItem
+            className="flex items-center gap-2 hover:scale-105 transition-all px-3 py-2 rounded-xl cursor-pointer font-semibold text-base shadow-sm group text-yellow-700 hover:bg-yellow-100/60"
+          >
+            <span className="text-lg">🤝</span>
+            Partener
+            <span className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-xs">
+              Business
+            </span>
+          </Link>
+          <Link
             to="/register/collaborator"
             onClick={() => setOpen(false)}
-            icon={<span className="text-lg">🧑‍💼</span>}
-            label="Colaborator"
-            subLabel="Freelancer"
-            className="text-yellow-700 hover:bg-yellow-100/60"
-          />
-          <MenuItem
+            className="flex items-center gap-2 hover:scale-105 transition-all px-3 py-2 rounded-xl cursor-pointer font-semibold text-base shadow-sm group text-yellow-700 hover:bg-yellow-100/60"
+          >
+            <span className="text-lg">🧑‍💼</span>
+            Colaborator
+            <span className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-xs">
+              Freelancer
+            </span>
+          </Link>
+          <Link
             to="/register/courier"
             onClick={() => setOpen(false)}
-            icon={<span className="text-lg">🚚</span>}
-            label="Curier"
-            subLabel="Livrări"
-            className="text-yellow-700 hover:bg-yellow-100/60"
-          />
+            className="flex items-center gap-2 hover:scale-105 transition-all px-3 py-2 rounded-xl cursor-pointer font-semibold text-base shadow-sm group text-yellow-700 hover:bg-yellow-100/60"
+          >
+            <span className="text-lg">🚚</span>
+            Curier
+            <span className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-xs">
+              Livrări
+            </span>
+          </Link>
         </DropdownContainer>
       )}
     </div>


### PR DESCRIPTION
## Summary
- replace static dropdown items with `react-router-dom` `Link`
- update CHANGELOG

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884e9910d88832d821d6968d6474a58