### PR TITLE
[Codex] register-tests - Add unit tests for role props

### DIFF
--- a/src/pages/register/__tests__/RegisterClient.test.tsx
+++ b/src/pages/register/__tests__/RegisterClient.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import { ROLE_CLIENT } from "@/shared/constants/roles";
+
+let receivedRole: string | undefined;
+vi.mock("@/shared/components/forms/RegisterForm", () => ({
+  __esModule: true,
+  default: (props: { role: string }) => {
+    receivedRole = props.role;
+    return <div data-testid="register-form" />;
+  }
+}));
+
+import RegisterClient from "../RegisterClient";
+
+describe("RegisterClient", () => {
+  it("paseaza rolul client catre RegisterForm", () => {
+    render(<RegisterClient />);
+    expect(receivedRole).toBe(ROLE_CLIENT);
+  });
+});

--- a/src/pages/register/__tests__/RegisterCollaborator.test.tsx
+++ b/src/pages/register/__tests__/RegisterCollaborator.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import { ROLE_COLLABORATOR } from "@/shared/constants/roles";
+
+let receivedRole: string | undefined;
+vi.mock("@/shared/components/forms/RegisterForm", () => ({
+  __esModule: true,
+  default: (props: { role: string }) => {
+    receivedRole = props.role;
+    return <div data-testid="register-form" />;
+  }
+}));
+
+import RegisterCollaborator from "../RegisterCollaborator";
+
+describe("RegisterCollaborator", () => {
+  it("paseaza rolul collaborator catre RegisterForm", () => {
+    render(<RegisterCollaborator />);
+    expect(receivedRole).toBe(ROLE_COLLABORATOR);
+  });
+});

--- a/src/pages/register/__tests__/RegisterCourier.test.tsx
+++ b/src/pages/register/__tests__/RegisterCourier.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import { ROLE_COURIER } from "@/shared/constants/roles";
+
+let receivedRole: string | undefined;
+vi.mock("@/shared/components/forms/RegisterForm", () => ({
+  __esModule: true,
+  default: (props: { role: string }) => {
+    receivedRole = props.role;
+    return <div data-testid="register-form" />;
+  }
+}));
+
+import RegisterCourier from "../RegisterCourier";
+
+describe("RegisterCourier", () => {
+  it("paseaza rolul courier catre RegisterForm", () => {
+    render(<RegisterCourier />);
+    expect(receivedRole).toBe(ROLE_COURIER);
+  });
+});

--- a/src/pages/register/__tests__/RegisterPartner.test.tsx
+++ b/src/pages/register/__tests__/RegisterPartner.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import { ROLE_PARTNER } from "@/shared/constants/roles";
+
+let receivedRole: string | undefined;
+vi.mock("@/shared/components/forms/RegisterForm", () => ({
+  __esModule: true,
+  default: (props: { role: string }) => {
+    receivedRole = props.role;
+    return <div data-testid="register-form" />;
+  }
+}));
+
+import RegisterPartner from "../RegisterPartner";
+
+describe("RegisterPartner", () => {
+  it("paseaza rolul partner catre RegisterForm", () => {
+    render(<RegisterPartner />);
+    expect(receivedRole).toBe(ROLE_PARTNER);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for register pages verifying `RegisterForm` gets the right role

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884eb04b1e4832d8b0a89bf6768ba4f