### PR TITLE
[Codex] docs - Document registration routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integrări viitoare cu notificări prin email și autentificare multi-factor
 - Export `registerRoutes` în router și test pentru verificarea rutelor
 - Dropdownul de înregistrare folosește acum link-uri `react-router-dom` pentru fiecare rol și închide meniul la click
+- Adăugat în README rutele de înregistrare și mențiunea despre `useRegister`
 
 ## [0.1.0] - 2025-08-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ să poată atașa tokenul curent și să reîncerce cererile după o eroare 401.
 ## Funcționalități Principale
 
 - **Autentificare**: Login, înregistrare, recuperare parolă
+  - Formularele dedicate fiecărui rol se găsesc la următoarele rute:
+    - `/register/client`
+    - `/register/partner`
+    - `/register/collaborator`
+    - `/register/courier`
+  - Toate trimit datele către `POST /v1/auth/register` folosind hook-ul `useRegister`.
 - **Gestionare Clienți**: Vizualizare, adăugare, editare și ștergere clienți
 - **Profil Utilizator**: Gestionarea informațiilor personale și preferințelor
 


### PR DESCRIPTION
## Summary
- document the four registration URLs in README
- note that forms use `useRegister` and POST `/v1/auth/register`
- update CHANGELOG

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884ec5e9aa0832dbcf1443ee9073de0